### PR TITLE
fix: add trailing separator to cwd check in isServerEntryOutsideOfCwd

### DIFF
--- a/src/runtime/importServerProductionEntry.ts
+++ b/src/runtime/importServerProductionEntry.ts
@@ -100,5 +100,5 @@ function isServerEntryOutsideOfCwd(paths: AutoImporterPaths): boolean | null {
 
   serverEntryFilePath = toPosixPath(serverEntryFilePath)
   assertPosixPath(cwd)
-  return !serverEntryFilePath.startsWith(cwd)
+  return !serverEntryFilePath.startsWith(cwd.endsWith('/') ? cwd : cwd + '/')
 }


### PR DESCRIPTION
## Summary

Fixes the monorepo path-prefix false-positive reported in #28.

`isServerEntryOutsideOfCwd` compared the server entry path against `cwd` with a bare `startsWith(cwd)`. When two app directories share a name prefix (e.g. `/repo/playground` and `/repo/playground-rsc`), the shorter path is a *string* prefix of the longer one, so the guard wrongly accepts a sibling app's server entry as belonging to `cwd`:

```js
"/repo/playground-rsc/dist/server/entry.mjs".startsWith("/repo/playground") // => true (WRONG)
```

**Fix:** append a trailing `/` to `cwd` before the comparison so only a genuine child path can match:

```js
// before
return !serverEntryFilePath.startsWith(cwd)

// after
return !serverEntryFilePath.startsWith(cwd.endsWith('/') ? cwd : cwd + '/')
```

This matches the patch applied in [rudderjs/rudder@c43e384](https://github.com/rudderjs/rudder/commit/c43e384bef029f827ead5f646c2cf7b116e1d0f1), where the fix reduced concurrent 4-app monorepo build crashes from ~3/12 to 0/30.

## Impact

- Only affects monorepos where two app directory names share a prefix.
- One-character change; no new dependencies or API surface.

Closes #28

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGswEpZkRjkiQzycf7BVd9)_